### PR TITLE
Ops: deploy to prod based on stable tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,22 +47,34 @@ jobs:
             pip install pre-commit
             pre-commit run -a
 
-  deploy:
+  deploy-to-dev:
     executor: aws-cli/default
     steps:
       - checkout
       - aws-cli/setup
       - run:
-          command: make deploy_lambda
+          command: make deploy_lambda STAGE=dev
+
+  deploy-to-prod:
+    executor: aws-cli/default
+    steps:
+      - checkout
+      - aws-cli/setup
+      - run:
+          command: make deploy_lambda STAGE=prod
 workflows:
   main:
     jobs:
       - build-and-test
       - code-style-checks
       - pre-commit-hooks
-      - deploy:
+      - deploy-to-dev:
           requires:
             - build-and-test
           filters:
             branches:
               only: main
+      - deploy-to-prod:
+          filters:
+            tags:
+              only: /v.*-stable/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
+STAGE = dev  # this is the environment we deploy to
+
 test:
 	docker-compose -f local.yml run --rm app python -m pytest
+
 build:
 	docker-compose -f local.yml build
 
@@ -8,4 +11,4 @@ deploy_lambda:
 	cd libs; zip -r9 ../function.zip .; cd ..
 	zip -rg function.zip app
 	zip -g function.zip handler.py
-	aws lambda update-function-code --function-name training-provider-api-dev-catalogue --zip-file fileb://function.zip
+	aws lambda update-function-code --function-name training-provider-api-$(STAGE)-catalogue --zip-file fileb://function.zip


### PR DESCRIPTION
Deploys the service to production when a tag is created ending with `-stable`

This doesn't run the tests again before deploying to production. That's under the assumption that tags ending with -stable are already verified on the dev environment.

In case you're thinking, but why not just run the tests, coverage checks, code checks, etc then deploy. That's basically because it's not supported easily by the CI. we need to duplicate lots of code. My plan is to only add those checks if we see that they're needed in the future.